### PR TITLE
Rename ReactiveOps to Fairwinds

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 ReactiveOps, Inc.
+Copyright (c) 2015 FairwindsOps Inc, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: Jason Bornhoft (credit to Bryan Traywick)
   description: Ansible role for HAProxy implementation
-  company: ReactiveOps Inc.
+  company: FairwindsOps Inc.
   license: MIT
   min_ansible_version: 1.2
   platforms:


### PR DESCRIPTION
Remaining mentions: 
```

```